### PR TITLE
Issue #SBCOSS-00: Downgrade Elasticsearch to version 7.10.2 for open source compliance

### DIFF
--- a/jobs-core/pom.xml
+++ b/jobs-core/pom.xml
@@ -160,7 +160,7 @@
         <dependency>
             <groupId>org.elasticsearch.client</groupId>
             <artifactId>elasticsearch-rest-high-level-client</artifactId>
-            <version>7.17.13</version>
+            <version>7.10.2</version>
         </dependency>
         <dependency>
             <groupId>com.twitter</groupId>

--- a/jobs-core/src/main/scala/org/sunbird/job/util/ElasticSearchUtil.scala
+++ b/jobs-core/src/main/scala/org/sunbird/job/util/ElasticSearchUtil.scala
@@ -14,7 +14,7 @@ import org.elasticsearch.action.update.UpdateRequest
 import org.elasticsearch.client.indices.{CreateIndexRequest, CreateIndexResponse}
 import org.elasticsearch.client.{Request, RequestOptions, Response, RestClient, RestClientBuilder, RestHighLevelClient}
 import org.elasticsearch.common.settings.Settings
-import org.elasticsearch.xcontent.XContentType
+import org.elasticsearch.common.xcontent.XContentType;
 import org.slf4j.LoggerFactory
 
 import java.io.IOException


### PR DESCRIPTION
## Summary
This PR downgrades the Elasticsearch client dependency from version 7.17.13 to 7.10.2 to maintain Apache 2.0 open source licensing compliance.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Downgrade Elasticsearch dependency to version 7.10.2 for open source compliance and update the import statement in ElasticSearchUtil.scala.

### Why are these changes being made?

The downgrade to version 7.10.2 is mandated for compliance with open source licensing requirements. Additionally, the import statement `org.elasticsearch.xcontent.XContentType` has been updated to `org.elasticsearch.common.xcontent.XContentType` to align with version 7.10.2's package structure.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->