### PR TITLE
Issue #SBCOSS-00: Add Redis Cache Cleanup to User Deletion Flink Job

### DIFF
--- a/user-org-jobs/user-deletion-cleanup/pom.xml
+++ b/user-org-jobs/user-deletion-cleanup/pom.xml
@@ -25,6 +25,7 @@
     <properties>
         <encoding>UTF-8</encoding>
         <scoverage.plugin.version>1.4.0</scoverage.plugin.version>
+        <redis.server.version>0.7.3</redis.server.version>
     </properties>
 
     <dependencies>
@@ -98,6 +99,12 @@
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-client</artifactId>
             <version>4.7.9.Final</version>
+        </dependency>
+        <dependency>
+            <groupId>it.ozimov</groupId>
+            <artifactId>embedded-redis</artifactId>
+            <version>${redis.server.version}</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/user-org-jobs/user-deletion-cleanup/src/main/scala/org/sunbird/job/deletioncleanup/task/UserDeletionCleanupConfig.scala
+++ b/user-org-jobs/user-deletion-cleanup/src/main/scala/org/sunbird/job/deletioncleanup/task/UserDeletionCleanupConfig.scala
@@ -77,6 +77,9 @@ class UserDeletionCleanupConfig(override val config: Config) extends BaseJobConf
   val keycloakPoolSize: Int = if (config.hasPath("sunbird_sso_pool_size")) config.getInt("sunbird_sso_pool_size") else 2
   val SUNBIRD_KEYCLOAK_USER_FEDERATION_PROVIDER_ID: String = config.getString("sunbird_keycloak_user_federation_provider_id")
 
+  //Redis configurations required to delete the user cache
+  val userDBIndex: Int = if (config.hasPath("user.redis.store")) config.getInt("user.redis.store") else 12
+  val userStoreKeyPrefix: String = "user:"
   // Consumers
   val userDeletionCleanupConsumer: String = "user-deletion-cleanup-consumer"
 

--- a/user-org-jobs/user-deletion-cleanup/src/main/scala/org/sunbird/job/deletioncleanup/task/UserDeletionCleanupConfig.scala
+++ b/user-org-jobs/user-deletion-cleanup/src/main/scala/org/sunbird/job/deletioncleanup/task/UserDeletionCleanupConfig.scala
@@ -78,6 +78,7 @@ class UserDeletionCleanupConfig(override val config: Config) extends BaseJobConf
   val SUNBIRD_KEYCLOAK_USER_FEDERATION_PROVIDER_ID: String = config.getString("sunbird_keycloak_user_federation_provider_id")
 
   //Redis configurations required to delete the user cache
+  //Redis configurations required to delete the user cache. DB index 12 is the dedicated index for user data in our system
   val userDBIndex: Int = if (config.hasPath("user.redis.store")) config.getInt("user.redis.store") else 12
   val userStoreKeyPrefix: String = "user:"
   // Consumers

--- a/user-org-jobs/user-deletion-cleanup/src/test/resources/test.conf
+++ b/user-org-jobs/user-deletion-cleanup/src/test/resources/test.conf
@@ -28,5 +28,11 @@ service {
 
 user_read_api = "/user/v5/read/"
 batch_search_api = "/course/v1/batch/list"
+sunbird_sso_realm = "sunbird"                                                                                                                                                              │
+sunbird_sso_client_secret = ""                                                                                                                                          │
+sunbird_sso_client_id = ""                                                                                                                                                              │
+sunbird_sso_password = ""                                                                                                                                                  │
+sunbird_sso_username = "admin"                                                                                                                                                             │
+sunbird_sso_url = "https://dev.sunbirded.org/auth/"
 
 sunbird_keycloak_user_federation_provider_id = "test_provider_id"

--- a/user-org-jobs/user-deletion-cleanup/src/test/resources/test.conf
+++ b/user-org-jobs/user-deletion-cleanup/src/test/resources/test.conf
@@ -28,11 +28,11 @@ service {
 
 user_read_api = "/user/v5/read/"
 batch_search_api = "/course/v1/batch/list"
-sunbird_sso_realm = "sunbird"                                                                                                                                                              │
-sunbird_sso_client_secret = ""                                                                                                                                          │
-sunbird_sso_client_id = ""                                                                                                                                                              │
-sunbird_sso_password = ""                                                                                                                                                  │
-sunbird_sso_username = "admin"                                                                                                                                                             │
+sunbird_sso_realm = "sunbird"
+sunbird_sso_client_secret = ""
+sunbird_sso_client_id = ""
+sunbird_sso_password = ""
+sunbird_sso_username = "admin"
 sunbird_sso_url = "https://dev.sunbirded.org/auth/"
 
 sunbird_keycloak_user_federation_provider_id = "test_provider_id"

--- a/user-org-jobs/user-deletion-cleanup/src/test/scala/org/sunbird/deletioncleanup/spec/UserDeletionCleanupFunctionTestSpec.scala
+++ b/user-org-jobs/user-deletion-cleanup/src/test/scala/org/sunbird/deletioncleanup/spec/UserDeletionCleanupFunctionTestSpec.scala
@@ -15,6 +15,7 @@ import org.sunbird.job.util.{CassandraUtil, HTTPResponse, HttpUtil}
 import org.sunbird.job.deletioncleanup.domain.Event
 import org.sunbird.job.deletioncleanup.task.{UserDeletionCleanupConfig, UserDeletionCleanupStreamTask}
 import org.sunbird.spec.{BaseMetricsReporter, BaseTestSpec}
+import redis.embedded.RedisServer
 
 
 class UserDeletionCleanupFunctionTestSpec extends BaseTestSpec {
@@ -34,11 +35,13 @@ class UserDeletionCleanupFunctionTestSpec extends BaseTestSpec {
   val jobConfig: UserDeletionCleanupConfig = new UserDeletionCleanupConfig(config)
   var mockHttpUtil: HttpUtil = mock[HttpUtil](Mockito.withSettings().serializable())
   var cassandraUtil: CassandraUtil = _
+  var redisServer: RedisServer = _
 
 
   override protected def beforeAll(): Unit = {
     super.beforeAll()
-
+    redisServer = new RedisServer(6340)
+    redisServer.start()
     EmbeddedCassandraServerHelper.startEmbeddedCassandra(80000L)
     cassandraUtil = new CassandraUtil(jobConfig.dbHost, jobConfig.dbPort, jobConfig.isMultiDCEnabled)
     val session = cassandraUtil.session
@@ -54,6 +57,7 @@ class UserDeletionCleanupFunctionTestSpec extends BaseTestSpec {
 
   override protected def afterAll(): Unit = {
     super.afterAll()
+    redisServer.stop()
     flinkCluster.after()
   }
 


### PR DESCRIPTION
## Summaary
This pull request enhances the **user-deletion-cleanup** Flink job by including Redis cache cleanup as part of the user deletion process. Previously, only the primary data source was being cleaned up. With this change, any associated Redis entries are also removed, ensuring complete user data cleanup across systems.

### Key Changes
- **Feature:** Implemented Redis cache deletion in the `user-deletion-cleanup` job.
- **Chore:** Added necessary configurations to support Redis deletion.
- **Fix:** Updated and fixed test cases to cover Redis cache cleanup scenarios.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add Redis cache cleanup functionality to the User Deletion Flink Job, updating dependencies, configurations, and test cases to support Redis interactions.

### Why are these changes being made?

These changes are being implemented to ensure that user data is fully removed, including cached data in Redis, when a user is deleted. Redis caching is integrated to optimize data retrieval, and this update extends functionality to clear relevant cache entries during the user deletion cleanup process to prevent stale data and potential inconsistencies. The approach enhances system reliability by adhering to data deletion policies systematically, and test cases have been updated to validate these new interactions.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->