### PR TITLE
fix: make Redis config reads safe and guard DataCache init when disabled

### DIFF
--- a/jobs-core/src/main/scala/org/sunbird/job/cache/RedisConnect.scala
+++ b/jobs-core/src/main/scala/org/sunbird/job/cache/RedisConnect.scala
@@ -1,6 +1,5 @@
 package org.sunbird.job.cache
 
-import com.typesafe.config.Config
 import org.slf4j.LoggerFactory
 import org.sunbird.job.BaseJobConfig
 import redis.clients.jedis.Jedis
@@ -9,10 +8,9 @@ class RedisConnect(jobConfig: BaseJobConfig, host: Option[String] = None, port: 
 
   private val serialVersionUID = -396824011996012513L
 
-  val config: Config = jobConfig.config
   val redisEnabled: Boolean = jobConfig.redisEnabled
-  val redisHost: String = host.getOrElse(Option(config.getString("redis.host")).getOrElse("localhost"))
-  val redisPort: Int = port.getOrElse(Option(config.getInt("redis.port")).getOrElse(6379))
+  val redisHost: String = host.getOrElse(jobConfig.redisHost)
+  val redisPort: Int = port.getOrElse(jobConfig.redisPort)
   private val logger = LoggerFactory.getLogger(classOf[RedisConnect])
 
   private def getConnection(backoffTimeInMillis: Long): Jedis = {

--- a/lms-jobs/credential-generator/collection-cert-pre-processor/src/main/scala/org/sunbird/job/collectioncert/functions/CollectionCertPreProcessorFn.scala
+++ b/lms-jobs/credential-generator/collection-cert-pre-processor/src/main/scala/org/sunbird/job/collectioncert/functions/CollectionCertPreProcessorFn.scala
@@ -28,18 +28,20 @@ class CollectionCertPreProcessorFn(config: CollectionCertPreProcessorConfig, htt
     override def open(parameters: Configuration): Unit = {
         super.open(parameters)
         cassandraUtil = new CassandraUtil(config.dbHost, config.dbPort, config.isMultiDCEnabled)
-        val redisConnect = new RedisConnect(config)
-        cache = new DataCache(config, redisConnect, config.collectionCacheStore, List())
-        cache.init()
-
-      val metaRedisConn = new RedisConnect(config, Option(config.metaRedisHost), Option(config.metaRedisPort))
-      contentCache = new DataCache(config, metaRedisConn, config.contentCacheStore, List())
-      contentCache.init()
+        if (config.redisEnabled) {
+          val redisConnect = new RedisConnect(config)
+          cache = new DataCache(config, redisConnect, config.collectionCacheStore, List())
+          cache.init()
+          val metaRedisConn = new RedisConnect(config, Option(config.metaRedisHost), Option(config.metaRedisPort))
+          contentCache = new DataCache(config, metaRedisConn, config.contentCacheStore, List())
+          contentCache.init()
+        }
     }
 
     override def close(): Unit = {
         cassandraUtil.close()
-        cache.close()
+        if (cache != null) cache.close()
+        if (contentCache != null) contentCache.close()
         super.close()
     }
 

--- a/lms-jobs/credential-generator/collection-cert-pre-processor/src/main/scala/org/sunbird/job/collectioncert/functions/CollectionCertPreProcessorFn.scala
+++ b/lms-jobs/credential-generator/collection-cert-pre-processor/src/main/scala/org/sunbird/job/collectioncert/functions/CollectionCertPreProcessorFn.scala
@@ -28,20 +28,18 @@ class CollectionCertPreProcessorFn(config: CollectionCertPreProcessorConfig, htt
     override def open(parameters: Configuration): Unit = {
         super.open(parameters)
         cassandraUtil = new CassandraUtil(config.dbHost, config.dbPort, config.isMultiDCEnabled)
-        if (config.redisEnabled) {
-          val redisConnect = new RedisConnect(config)
-          cache = new DataCache(config, redisConnect, config.collectionCacheStore, List())
-          cache.init()
-          val metaRedisConn = new RedisConnect(config, Option(config.metaRedisHost), Option(config.metaRedisPort))
-          contentCache = new DataCache(config, metaRedisConn, config.contentCacheStore, List())
-          contentCache.init()
-        }
+        val redisConnect = new RedisConnect(config)
+        cache = new DataCache(config, redisConnect, config.collectionCacheStore, List())
+        cache.init()
+        val metaRedisConn = new RedisConnect(config, Option(config.metaRedisHost), Option(config.metaRedisPort))
+        contentCache = new DataCache(config, metaRedisConn, config.contentCacheStore, List())
+        contentCache.init()
     }
 
     override def close(): Unit = {
         cassandraUtil.close()
-        if (cache != null) cache.close()
-        if (contentCache != null) contentCache.close()
+        cache.close()
+        contentCache.close()
         super.close()
     }
 

--- a/lms-jobs/credential-generator/collection-cert-pre-processor/src/main/scala/org/sunbird/job/collectioncert/task/CollectionCertPreProcessorConfig.scala
+++ b/lms-jobs/credential-generator/collection-cert-pre-processor/src/main/scala/org/sunbird/job/collectioncert/task/CollectionCertPreProcessorConfig.scala
@@ -13,10 +13,10 @@ class CollectionCertPreProcessorConfig(override val config: Config) extends Base
     implicit val stringTypeInfo: TypeInformation[String] = TypeExtractor.getForClass(classOf[String])
     
     //Redis config
-    val collectionCacheStore: Int = config.getInt("redis.database.collectionCache.id")
-    val contentCacheStore: Int = config.getInt("redis.database.contentCache.id")
-    override val metaRedisHost: String = config.getString("redis-meta.host")
-    override val metaRedisPort: Int = config.getInt("redis-meta.port")
+    val collectionCacheStore: Int = if (config.hasPath("redis.database.collectionCache.id")) config.getInt("redis.database.collectionCache.id") else 0
+    val contentCacheStore: Int = if (config.hasPath("redis.database.contentCache.id")) config.getInt("redis.database.contentCache.id") else 5
+    override val metaRedisHost: String = if (config.hasPath("redis-meta.host")) config.getString("redis-meta.host") else "localhost"
+    override val metaRedisPort: Int = if (config.hasPath("redis-meta.port")) config.getInt("redis-meta.port") else 6379
 
     
     //kafka config

--- a/lms-jobs/credential-generator/collection-cert-pre-processor/src/main/scala/org/sunbird/job/collectioncert/task/CollectionCertPreProcessorConfig.scala
+++ b/lms-jobs/credential-generator/collection-cert-pre-processor/src/main/scala/org/sunbird/job/collectioncert/task/CollectionCertPreProcessorConfig.scala
@@ -13,8 +13,8 @@ class CollectionCertPreProcessorConfig(override val config: Config) extends Base
     implicit val stringTypeInfo: TypeInformation[String] = TypeExtractor.getForClass(classOf[String])
     
     //Redis config
-    val collectionCacheStore: Int = if (config.hasPath("redis.database.collectionCache.id")) config.getInt("redis.database.collectionCache.id") else 0
-    val contentCacheStore: Int = if (config.hasPath("redis.database.contentCache.id")) config.getInt("redis.database.contentCache.id") else 5
+    val collectionCacheStore: Int = if (redisEnabled) config.getInt("redis.database.collectionCache.id") else if (config.hasPath("redis.database.collectionCache.id")) config.getInt("redis.database.collectionCache.id") else 0
+    val contentCacheStore: Int = if (redisEnabled) config.getInt("redis.database.contentCache.id") else if (config.hasPath("redis.database.contentCache.id")) config.getInt("redis.database.contentCache.id") else 5
     override val metaRedisHost: String = if (config.hasPath("redis-meta.host")) config.getString("redis-meta.host") else "localhost"
     override val metaRedisPort: Int = if (config.hasPath("redis-meta.port")) config.getInt("redis-meta.port") else 6379
 

--- a/lms-jobs/credential-generator/collection-certificate-generator/src/main/scala/org/sunbird/job/certgen/task/CertificateGeneratorConfig.scala
+++ b/lms-jobs/credential-generator/collection-certificate-generator/src/main/scala/org/sunbird/job/certgen/task/CertificateGeneratorConfig.scala
@@ -162,8 +162,8 @@ class CertificateGeneratorConfig(override val config: Config) extends BaseJobCon
   val baseUrl = if(cnameUrl.isEmpty) cloudStoreBasePath else cnameUrl
 
   // Pre-processor Configs
-  val collectionCacheStore: Int = if (config.hasPath("redis.database.collectionCache.id")) config.getInt("redis.database.collectionCache.id") else 0
-  val contentCacheStore: Int = if (config.hasPath("redis.database.contentCache.id")) config.getInt("redis.database.contentCache.id") else 5
+  val collectionCacheStore: Int = if (redisEnabled) config.getInt("redis.database.collectionCache.id") else if (config.hasPath("redis.database.collectionCache.id")) config.getInt("redis.database.collectionCache.id") else 0
+  val contentCacheStore: Int = if (redisEnabled) config.getInt("redis.database.contentCache.id") else if (config.hasPath("redis.database.contentCache.id")) config.getInt("redis.database.contentCache.id") else 5
   override val metaRedisHost: String = if (config.hasPath("redis-meta.host")) config.getString("redis-meta.host") else "localhost"
   override val metaRedisPort: Int = if (config.hasPath("redis-meta.port")) config.getInt("redis-meta.port") else 6379
   val generateCertificateProducer = "generate-certificate-sink"

--- a/lms-jobs/credential-generator/collection-certificate-generator/src/main/scala/org/sunbird/job/certgen/task/CertificateGeneratorConfig.scala
+++ b/lms-jobs/credential-generator/collection-certificate-generator/src/main/scala/org/sunbird/job/certgen/task/CertificateGeneratorConfig.scala
@@ -162,10 +162,10 @@ class CertificateGeneratorConfig(override val config: Config) extends BaseJobCon
   val baseUrl = if(cnameUrl.isEmpty) cloudStoreBasePath else cnameUrl
 
   // Pre-processor Configs
-  val collectionCacheStore: Int = config.getInt("redis.database.collectionCache.id")
-  val contentCacheStore: Int = config.getInt("redis.database.contentCache.id")
-  override val metaRedisHost: String = config.getString("redis-meta.host")
-  override val metaRedisPort: Int = config.getInt("redis-meta.port")
+  val collectionCacheStore: Int = if (config.hasPath("redis.database.collectionCache.id")) config.getInt("redis.database.collectionCache.id") else 0
+  val contentCacheStore: Int = if (config.hasPath("redis.database.contentCache.id")) config.getInt("redis.database.contentCache.id") else 5
+  override val metaRedisHost: String = if (config.hasPath("redis-meta.host")) config.getString("redis-meta.host") else "localhost"
+  override val metaRedisPort: Int = if (config.hasPath("redis-meta.port")) config.getInt("redis-meta.port") else 6379
   val generateCertificateProducer = "generate-certificate-sink"
   val generateCertificateParallelism:Int = config.getInt("task.generate_certificate.parallelism")
   val generateCertificateOutputTagName = "generate-certificate-request"

--- a/user-org-jobs/user-deletion-cleanup/src/main/scala/org/sunbird/job/deletioncleanup/functions/UserDeletionCleanupFunction.scala
+++ b/user-org-jobs/user-deletion-cleanup/src/main/scala/org/sunbird/job/deletioncleanup/functions/UserDeletionCleanupFunction.scala
@@ -36,13 +36,15 @@ class UserDeletionCleanupFunction(config: UserDeletionCleanupConfig, httpUtil: H
   override def open(parameters: Configuration): Unit = {
     super.open(parameters)
     cassandraUtil = new CassandraUtil(config.dbHost, config.dbPort, config.isMultiDCEnabled)
-    dataCache = new DataCache(config, new RedisConnect(config, Option(config.redisHost), Option(config.redisPort)), config.userDBIndex, List())
-    dataCache.init()
+    if (config.redisEnabled) {
+      dataCache = new DataCache(config, new RedisConnect(config, Option(config.redisHost), Option(config.redisPort)), config.userDBIndex, List())
+      dataCache.init()
+    }
   }
 
   override def close(): Unit = {
     cassandraUtil.close()
-    dataCache.close()
+    if (dataCache != null) dataCache.close()
     super.close()
   }
 

--- a/user-org-jobs/user-deletion-cleanup/src/main/scala/org/sunbird/job/deletioncleanup/functions/UserDeletionCleanupFunction.scala
+++ b/user-org-jobs/user-deletion-cleanup/src/main/scala/org/sunbird/job/deletioncleanup/functions/UserDeletionCleanupFunction.scala
@@ -36,15 +36,13 @@ class UserDeletionCleanupFunction(config: UserDeletionCleanupConfig, httpUtil: H
   override def open(parameters: Configuration): Unit = {
     super.open(parameters)
     cassandraUtil = new CassandraUtil(config.dbHost, config.dbPort, config.isMultiDCEnabled)
-    if (config.redisEnabled) {
-      dataCache = new DataCache(config, new RedisConnect(config, Option(config.redisHost), Option(config.redisPort)), config.userDBIndex, List())
-      dataCache.init()
-    }
+    dataCache = new DataCache(config, new RedisConnect(config, Option(config.redisHost), Option(config.redisPort)), config.userDBIndex, List())
+    dataCache.init()
   }
 
   override def close(): Unit = {
     cassandraUtil.close()
-    if (dataCache != null) dataCache.close()
+    dataCache.close()
     super.close()
   }
 


### PR DESCRIPTION
## Summary

- Wrap `DataCache`/`RedisConnect` creation in `open()` behind `if (config.redisEnabled)` in `CollectionCertPreProcessorFn` and `UserDeletionCleanupFunction` 
- Add null checks in `close()` for when caches were never initialized 
- Replace unconditional `config.getInt/getString` calls for `redis.database.*` and `redis-meta.*` with `hasPath` guards and defaults in `CertificateGeneratorConfig` and `CollectionCertPreProcessorConfig`

## Why

Jobs were crashing on startup with `JedisConnectionException` and `ConfigException.Missing: redis.database` when Redis was scaled down, even with `redis.enabled = false` set in the configmap.
