### PR TITLE
Fix: Robust metric lookup using last scope component

### DIFF
--- a/jobs-core/src/test/scala/org/sunbird/spec/BaseMetricsReporter.scala
+++ b/jobs-core/src/test/scala/org/sunbird/spec/BaseMetricsReporter.scala
@@ -15,7 +15,7 @@ class BaseMetricsReporter extends MetricReporter {
   override def notifyOfAddedMetric(metric: Metric, metricName: String, group: MetricGroup): Unit = {
     metric match {
       case gauge: Gauge[_] => {
-        val gaugeKey = group.getScopeComponents.toSeq.drop(6).mkString(".") + "." + metricName
+        val gaugeKey = group.getScopeComponents.last + "." + metricName
         BaseMetricsReporter.gaugeMetrics(gaugeKey) = gauge.asInstanceOf[Gauge[Long]]
       }
       case _ => // Do Nothing


### PR DESCRIPTION
- Update BaseMetricsReporter to use group.getScopeComponents.last as jobName
- Ensures compatibility with Flink 1.18 metric scope changes in local tests

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

### Type of change

Please choose appropriate options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes in the below checkboxes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Ran Test A
- [ ] Ran Test B

**Test Configuration**:
* Software versions:
* Hardware versions:

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules