### PR TITLE
fix: update test metric reporter for Flink 1.18 API

### DIFF
--- a/jobs-core/src/test/resources/META-INF/services/org.apache.flink.metrics.reporter.MetricReporterFactory
+++ b/jobs-core/src/test/resources/META-INF/services/org.apache.flink.metrics.reporter.MetricReporterFactory
@@ -1,0 +1,1 @@
+org.sunbird.spec.BaseMetricsReporterFactory

--- a/jobs-core/src/test/scala/org/sunbird/spec/BaseMetricsReporter.scala
+++ b/jobs-core/src/test/scala/org/sunbird/spec/BaseMetricsReporter.scala
@@ -1,9 +1,10 @@
 package org.sunbird.spec
 
 import org.apache.flink.metrics.Gauge
-import org.apache.flink.metrics.reporter.MetricReporter
+import org.apache.flink.metrics.reporter.{MetricReporter, MetricReporterFactory}
 import org.apache.flink.metrics.{Metric, MetricConfig, MetricGroup}
 
+import java.util.Properties
 import scala.collection.mutable
 
 class BaseMetricsReporter extends MetricReporter {
@@ -22,6 +23,12 @@ class BaseMetricsReporter extends MetricReporter {
     }
   }
   override def notifyOfRemovedMetric(metric: Metric, metricName: String, group: MetricGroup): Unit = {}
+}
+
+class BaseMetricsReporterFactory extends MetricReporterFactory {
+  override def createMetricReporter(properties: Properties): MetricReporter = {
+    new BaseMetricsReporter()
+  }
 }
 
 object BaseMetricsReporter {

--- a/jobs-core/src/test/scala/org/sunbird/spec/BaseTestSpec.scala
+++ b/jobs-core/src/test/scala/org/sunbird/spec/BaseTestSpec.scala
@@ -8,8 +8,8 @@ class BaseTestSpec extends FlatSpec with Matchers with BeforeAndAfterAll with Mo
 
   def testConfiguration(): Configuration = {
     val config = new Configuration()
-    config.setString("metrics.reporter", "job_metrics_reporter")
-    config.setString("metrics.reporter.job_metrics_reporter.class", classOf[BaseMetricsReporter].getName)
+    config.setString("metrics.reporters", "job_metrics_reporter")
+    config.setString("metrics.reporter.job_metrics_reporter.factory.class", classOf[BaseMetricsReporterFactory].getName)
     config
   }
 

--- a/user-org-jobs/user-deletion-cleanup/src/test/scala/org/sunbird/deletioncleanup/spec/UserDeletionCleanupFunctionTestSpec.scala
+++ b/user-org-jobs/user-deletion-cleanup/src/test/scala/org/sunbird/deletioncleanup/spec/UserDeletionCleanupFunctionTestSpec.scala
@@ -36,13 +36,13 @@ class UserDeletionCleanupFunctionTestSpec extends BaseTestSpec {
   val jobConfig: UserDeletionCleanupConfig = new UserDeletionCleanupConfig(config)
   var mockHttpUtil: HttpUtil = mock[HttpUtil](Mockito.withSettings().serializable())
   var cassandraUtil: CassandraUtil = _
-  // var redisServer: RedisServer = _
+  var redisServer: RedisServer = _
 
 
   override protected def beforeAll(): Unit = {
     super.beforeAll()
-    // redisServer = new RedisServer(6340)
-    // redisServer.start()
+    redisServer = new RedisServer(6340)
+    redisServer.start()
     EmbeddedCassandraServerHelper.startEmbeddedCassandra(80000L)
     cassandraUtil = new CassandraUtil(jobConfig.dbHost, jobConfig.dbPort, jobConfig.isMultiDCEnabled)
     val session = cassandraUtil.session
@@ -58,7 +58,7 @@ class UserDeletionCleanupFunctionTestSpec extends BaseTestSpec {
 
   override protected def afterAll(): Unit = {
     super.afterAll()
-    // redisServer.stop()
+    redisServer.stop()
     flinkCluster.after()
   }
 

--- a/user-org-jobs/user-deletion-cleanup/src/test/scala/org/sunbird/deletioncleanup/spec/UserDeletionCleanupFunctionTestSpec.scala
+++ b/user-org-jobs/user-deletion-cleanup/src/test/scala/org/sunbird/deletioncleanup/spec/UserDeletionCleanupFunctionTestSpec.scala
@@ -36,13 +36,13 @@ class UserDeletionCleanupFunctionTestSpec extends BaseTestSpec {
   val jobConfig: UserDeletionCleanupConfig = new UserDeletionCleanupConfig(config)
   var mockHttpUtil: HttpUtil = mock[HttpUtil](Mockito.withSettings().serializable())
   var cassandraUtil: CassandraUtil = _
-  var redisServer: RedisServer = _
+  // var redisServer: RedisServer = _
 
 
   override protected def beforeAll(): Unit = {
     super.beforeAll()
-    redisServer = new RedisServer(6340)
-    redisServer.start()
+    // redisServer = new RedisServer(6340)
+    // redisServer.start()
     EmbeddedCassandraServerHelper.startEmbeddedCassandra(80000L)
     cassandraUtil = new CassandraUtil(jobConfig.dbHost, jobConfig.dbPort, jobConfig.isMultiDCEnabled)
     val session = cassandraUtil.session
@@ -58,7 +58,7 @@ class UserDeletionCleanupFunctionTestSpec extends BaseTestSpec {
 
   override protected def afterAll(): Unit = {
     super.afterAll()
-    redisServer.stop()
+    // redisServer.stop()
     flinkCluster.after()
   }
 


### PR DESCRIPTION
## Summary

Flink 1.18 dropped support for direct `MetricReporter` class loading via `metrics.reporter.<name>.class`. Reporters must now be loaded through `MetricReporterFactory` via Java SPI (`ServiceLoader`). This caused all test assertions on gauge metrics to fail with `key not found` because the `BaseMetricsReporter` was never registered.

### Changes

- **`BaseMetricsReporter.scala`**: Add `BaseMetricsReporterFactory` implementing `MetricReporterFactory` — creates `BaseMetricsReporter` instances when Flink's `ServiceLoader` discovers it
- **`BaseTestSpec.scala`**: Update config keys:
  - `metrics.reporter` → `metrics.reporters` (plural, required in Flink 1.14+)
  - `metrics.reporter.<name>.class` → `metrics.reporter.<name>.factory.class`
- **`META-INF/services/org.apache.flink.metrics.reporter.MetricReporterFactory`**: SPI registration file so Flink's `ServiceLoader` discovers the factory at test runtime
- **`UserDeletionCleanupFunctionTestSpec.scala`**: Use external Docker Redis instead of embedded `RedisServer`

### Root Cause

In Flink 1.18's `ReporterSetup.loadReporter()`, the `.class` config path now logs a warning and returns `Optional.empty()`:
> "The reporter configuration of '{}' configures the reporter class, which is a no longer supported approach to configure reporters. Please configure a factory class instead."

The factory is discovered via `ServiceLoader.load(MetricReporterFactory.class)` in `getAllReporterFactories()`, which requires the SPI file in `META-INF/services/`.

## Test Plan

- [x] `UserDeletionCleanupFunctionTestSpec` passes — gauge metrics correctly registered and asserted
- [ ] Run full test suite to verify all test specs that assert on `BaseMetricsReporter.gaugeMetrics`

🤖 Generated with [Claude Code](https://claude.com/claude-code)