### PR TITLE
Enable dependabot and dependency-submission workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"

--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -1,0 +1,27 @@
+name: Dependency Submission (Maven)
+
+on:
+  push:
+    branches: ["master"]
+  pull_request:
+    branches: ["master"]
+
+permissions:
+  contents: write
+
+jobs:
+  dependency-submission:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Submit Maven Dependencies
+        uses: advanced-security/maven-dependency-submission-action@v5
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- Add .github/dependabot.yml for maven ecosystem (multi-module monorepo)
- Add .github/workflows/dependency-submission.yml
  - Plugin: advanced-security/maven-dependency-submission-action@v5
  - Captures full transitive dependency set (direct + transitive) via root pom
  - Triggers: push and pull_request on master