### PR TITLE
fix(compliance): stop false redisCache deletion audit + drop full-event PII log

### DIFF
--- a/user-org-jobs/user-deletion-cleanup/src/main/scala/org/sunbird/job/deletioncleanup/functions/UserDeletionCleanupFunction.scala
+++ b/user-org-jobs/user-deletion-cleanup/src/main/scala/org/sunbird/job/deletioncleanup/functions/UserDeletionCleanupFunction.scala
@@ -47,7 +47,6 @@ class UserDeletionCleanupFunction(config: UserDeletionCleanupConfig, httpUtil: H
   }
 
   override def processElement(event: Event, context: ProcessFunction[Event, Event]#Context, metrics: Metrics): Unit = {
-    logger.info(s"${event}")
     val entryLog = s"Entry Log:UserDeletionCleanup, Message:Context ${event.context}"
     logger.info(entryLog)
     metrics.incCounter(config.totalEventsCount)
@@ -95,8 +94,10 @@ class UserDeletionCleanupFunction(config: UserDeletionCleanupConfig, httpUtil: H
             val key: String = config.userStoreKeyPrefix + event.userId
             logger.info(s"UserDeletionCleanupFunction:processElement: Clearing user cache with key: $key")
             dataCache.del(key)
-            logger.info(s"UserDeletionCleanupFunction:processElement: User cache with $key cleared")
-            deletionStatus = deletionStatus + ("redisCache" -> true)
+            // Only report redisCache deletion as done when Redis is actually enabled.
+            // DataCache.del is a no-op when redis.enabled=false (the default), so hardcoding
+            // `true` here produced a false compliance-audit trail claiming the cache was purged.
+            deletionStatus = deletionStatus + ("redisCache" -> config.redisEnabled)
 
             // remove user entries from externalId table
             val dbUserExternalIds: List[Map[String, String]] = getUserExternalIds(event.userId)(config, cassandraUtil)


### PR DESCRIPTION
## Summary
Safe, self-contained slice of the **D1** (CRITICAL/compliance) and **D3** (PII-in-logs) findings in [`implementation-designs/data-pipeline.md`](../../implementation-designs/data-pipeline.md), in `UserDeletionCleanupFunction`.

### The bug (false compliance audit)
The deletion audit map seeded `redisCache -> false`, then set `redisCache -> true` **unconditionally** right after `dataCache.del(key)`. But `DataCache.del` is a **no-op** that only logs when `redis.enabled=false` — and that's the **default** (`BaseJobConfig.scala:28`). So the emitted AUDIT telemetry claimed the user's Redis cache was purged **when it was not** — a false Right-to-Erasure (DPDP/GDPR Art.17) compliance trail.

Separately, `logger.info(s"${event}")` dumped the **entire deletion event** (userId + other PII) to logs at INFO.

### The fix
- `redisCache -> config.redisEnabled` — the flag is `true` only when Redis is actually enabled (i.e. the `del` could run), so the audit is truthful.
- Removed the full-event PII log line.

Two-line behavioral change, no new stores/wiring, fully reversible.

## Verification
- `jobs-core` + `user-deletion-cleanup` compile (main + test Scala) under **JDK 11** (`mvn -pl user-org-jobs/user-deletion-cleanup -am test-compile` → BUILD SUCCESS).

## Scope / deferred
The full **D1** purge — ES `user` index, `user_consent` / `user_declarations` / `user_feed` / cert-registry deletes, per-store verify-then-flag, ML-PII delegation — plus the jobs-core `DataCache.del` `Unit`→`Long` verification are intentionally **not** here: they need net-new store wiring, **DBA delete grants**, are **irreversible**, and per the design must ship behind **per-store feature flags** with non-prod validation and DB backups. This PR makes the *audit honest* now; the expanded purge is coordinated L-effort work.