### PR TITLE
build: upgrade Flink from 1.18.1 to 1.20.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,15 +134,15 @@ If no profile is specified, the default build targets Azure.
 
 > Use this option to run the job the same way it runs in production.
 
-1. Download and extract Flink 1.18.1:
+1. Download and extract Flink 1.20.5:
    ```shell
-   wget https://dlcdn.apache.org/flink/flink-1.18.1/flink-1.18.1-bin-scala_2.12.tgz
-   tar xzf flink-1.18.1-bin-scala_2.12.tgz
+   wget https://dlcdn.apache.org/flink/flink-1.20.5/flink-1.20.5-bin-scala_2.12.tgz
+   tar xzf flink-1.20.5-bin-scala_2.12.tgz
    ```
 
 2. Start the Flink cluster:
    ```shell
-   cd flink-1.18.1
+   cd flink-1.20.5
    ./bin/start-cluster.sh
    ```
    Verify: open http://localhost:8081 — you should see the Flink dashboard with 1 TaskManager.
@@ -185,11 +185,11 @@ If no profile is specified, the default build targets Azure.
    </dependency>
    ```
 
-   Comment out the `provided` scope on `flink-streaming-scala`:
+   Comment out the `provided` scope on `flink-streaming-java`:
    ```xml
    <dependency>
      <groupId>org.apache.flink</groupId>
-     <artifactId>flink-streaming-scala_${scala.version}</artifactId>
+     <artifactId>flink-streaming-java</artifactId>
      <version>${flink.version}</version>
      <!-- <scope>provided</scope> -->
    </dependency>

--- a/jobs-core/pom.xml
+++ b/jobs-core/pom.xml
@@ -20,19 +20,8 @@
     <dependencies>
         <dependency>
             <groupId>org.apache.flink</groupId>
-            <artifactId>flink-streaming-scala_${scala.version}</artifactId>
-            <version>${flink.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.lz4</groupId>
-                    <artifactId>lz4-java</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.flink</groupId>
             <artifactId>flink-connector-kafka</artifactId>
-            <version>3.2.0-1.18</version>
+            <version>3.4.0-1.20</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.lz4</groupId>
@@ -44,6 +33,17 @@
             <groupId>org.apache.flink</groupId>
             <artifactId>flink-connector-base</artifactId>
             <version>${flink.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-streaming-java</artifactId>
+            <version>${flink.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.lz4</groupId>
+                    <artifactId>lz4-java</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.kafka</groupId>

--- a/jobs-core/src/main/scala/org/sunbird/job/BaseProcessFunction.scala
+++ b/jobs-core/src/main/scala/org/sunbird/job/BaseProcessFunction.scala
@@ -5,7 +5,7 @@ import java.util.concurrent.atomic.AtomicLong
 import org.apache.flink.metrics.Gauge
 import org.apache.flink.configuration.Configuration
 import org.apache.flink.streaming.api.functions.{KeyedProcessFunction, ProcessFunction}
-import org.apache.flink.streaming.api.scala.function.ProcessWindowFunction
+import org.apache.flink.streaming.api.functions.windowing.ProcessWindowFunction
 import org.apache.flink.streaming.api.windowing.windows.{GlobalWindow, TimeWindow}
 import org.apache.flink.util.Collector
 
@@ -64,10 +64,10 @@ abstract class WindowBaseProcessFunction[I, O, K](config: BaseJobConfig) extends
 
   def process(key: K,
               context: ProcessWindowFunction[I, O, K, GlobalWindow]#Context,
-              elements: Iterable[I],
+              elements: java.lang.Iterable[I],
               metrics: Metrics): Unit
 
-  override def process(key: K, context: Context, elements: Iterable[I], out: Collector[O]): Unit = {
+  override def process(key: K, context: ProcessWindowFunction[I, O, K, GlobalWindow]#Context, elements: java.lang.Iterable[I], out: Collector[O]): Unit = {
     process(key, context, elements, metrics)
   }
 }
@@ -86,10 +86,10 @@ abstract class TimeWindowBaseProcessFunction[I, O, K](config: BaseJobConfig) ext
 
   def process(key: K,
               context: ProcessWindowFunction[I, O, K, TimeWindow]#Context,
-              elements: Iterable[I],
+              elements: java.lang.Iterable[I],
               metrics: Metrics): Unit
 
-  override def process(key: K, context: Context, elements: Iterable[I], out: Collector[O]): Unit = {
+  override def process(key: K, context: ProcessWindowFunction[I, O, K, TimeWindow]#Context, elements: java.lang.Iterable[I], out: Collector[O]): Unit = {
     process(key, context, elements, metrics)
   }
 }

--- a/jobs-core/src/main/scala/org/sunbird/job/util/FlinkUtil.scala
+++ b/jobs-core/src/main/scala/org/sunbird/job/util/FlinkUtil.scala
@@ -5,7 +5,7 @@ import org.apache.flink.runtime.state.hashmap.HashMapStateBackend
 import org.apache.flink.runtime.state.storage.FileSystemCheckpointStorage
 import org.apache.flink.streaming.api.environment.CheckpointConfig
 import org.apache.flink.streaming.api.environment.CheckpointConfig.ExternalizedCheckpointCleanup
-import org.apache.flink.streaming.api.scala.StreamExecutionEnvironment
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment
 import org.sunbird.job.BaseJobConfig
 
 object FlinkUtil {

--- a/jobs-core/src/test/scala/org/sunbird/spec/BaseProcessFunctionTestSpec.scala
+++ b/jobs-core/src/test/scala/org/sunbird/spec/BaseProcessFunctionTestSpec.scala
@@ -5,8 +5,10 @@ import com.typesafe.config.{Config, ConfigFactory}
 import io.github.embeddedkafka.EmbeddedKafka._
 import io.github.embeddedkafka.{EmbeddedKafka, EmbeddedKafkaConfig}
 import org.apache.flink.api.common.eventtime.WatermarkStrategy
+import org.apache.flink.api.common.typeinfo.TypeInformation
+import org.apache.flink.api.java.typeutils.TypeExtractor
 import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration
-import org.apache.flink.streaming.api.scala._
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment
 import org.apache.flink.test.util.MiniClusterWithClientResource
 import org.apache.kafka.common.serialization.StringDeserializer
 import org.scalatest.Matchers
@@ -26,6 +28,7 @@ class BaseProcessFunctionTestSpec extends BaseSpec with Matchers {
   val config: Config = ConfigFactory.load("base-test.conf")
   val bsConfig = new BaseProcessTestConfig(config)
   val gson = new Gson()
+  implicit val stringTypeInfo: TypeInformation[String] = TypeExtractor.getForClass(classOf[String])
 
   val kafkaConnector = new FlinkKafkaConnector(bsConfig)
 

--- a/jobs-core/src/test/scala/org/sunbird/spec/BaseProcessTestConfig.scala
+++ b/jobs-core/src/test/scala/org/sunbird/spec/BaseProcessTestConfig.scala
@@ -4,7 +4,7 @@ import java.util
 import com.typesafe.config.Config
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.java.typeutils.TypeExtractor
-import org.apache.flink.streaming.api.scala.OutputTag
+import org.apache.flink.util.OutputTag
 import org.sunbird.job.BaseJobConfig
 import org.sunbird.job.domain.reader.JobRequest
 
@@ -12,10 +12,11 @@ class BaseProcessTestConfig(override val config: Config) extends BaseJobConfig(c
   private val serialVersionUID = -2349318979085017498L
   implicit val mapTypeInfo: TypeInformation[util.Map[String, AnyRef]] = TypeExtractor.getForClass(classOf[util.Map[String, AnyRef]])
   implicit val jobReqTypeInfo: TypeInformation[TestJobRequest] = TypeExtractor.getForClass(classOf[TestJobRequest])
+  implicit val stringTypeInfo: TypeInformation[String] = TypeExtractor.getForClass(classOf[String])
 
-  val mapOutputTag: OutputTag[util.Map[String, AnyRef]] = OutputTag[util.Map[String, AnyRef]]("test-map-stream-tag")
-  val stringOutputTag: OutputTag[String] = OutputTag[String]("test-string-stream-tag")
-  val jobRequestOutputTag: OutputTag[TestJobRequest] = OutputTag[TestJobRequest]("test-job-request-stream-tag")
+  val mapOutputTag: OutputTag[util.Map[String, AnyRef]] = new OutputTag[util.Map[String, AnyRef]]("test-map-stream-tag", mapTypeInfo)
+  val stringOutputTag: OutputTag[String] = new OutputTag[String]("test-string-stream-tag", stringTypeInfo)
+  val jobRequestOutputTag: OutputTag[TestJobRequest] = new OutputTag[TestJobRequest]("test-job-request-stream-tag", jobReqTypeInfo)
 
   val kafkaMapInputTopic: String = config.getString("kafka.map.input.topic")
   val kafkaMapOutputTopic: String = config.getString("kafka.map.output.topic")

--- a/jobs-core/src/test/scala/org/sunbird/spec/CoreTestSpec.scala
+++ b/jobs-core/src/test/scala/org/sunbird/spec/CoreTestSpec.scala
@@ -3,7 +3,7 @@ package org.sunbird.spec
 import java.util
 
 import com.typesafe.config.{Config, ConfigFactory}
-import org.apache.flink.streaming.api.scala.StreamExecutionEnvironment
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment
 import org.scalatest.Matchers
 import org.scalatestplus.mockito.MockitoSugar
 import org.sunbird.fixture.EventFixture

--- a/jobs-distribution/Dockerfile
+++ b/jobs-distribution/Dockerfile
@@ -1,4 +1,4 @@
-FROM flink:1.18.1-scala_2.12-java11 AS base
+FROM flink:1.20.5-scala_2.12-java11 AS base
 
 USER root
 RUN apt-get update && apt-get dist-upgrade -y && \
@@ -25,7 +25,7 @@ ENV cloud_storage_auth_type=OIDC
 FROM base AS azure
 ENV cloud_storage_type=azure
 RUN mkdir -p $FLINK_HOME/plugins/azure-fs-hadoop && \
-    cp $FLINK_HOME/opt/flink-azure-fs-hadoop-1.18.1.jar $FLINK_HOME/plugins/azure-fs-hadoop/
+    cp $FLINK_HOME/opt/flink-azure-fs-hadoop-1.20.5.jar $FLINK_HOME/plugins/azure-fs-hadoop/
 COPY target/azure-plugin/ $FLINK_HOME/plugins/azure-fs-hadoop/
 USER flink
 
@@ -34,12 +34,12 @@ FROM base AS gcloud
 ENV cloud_storage_type=gcloud
 COPY lib/gcs-connector-hadoop2-2.2.0.jar $FLINK_HOME/lib/
 RUN mkdir -p $FLINK_HOME/plugins/gs-fs-hadoop && \
-    cp $FLINK_HOME/opt/flink-gs-fs-hadoop-1.18.1.jar $FLINK_HOME/plugins/gs-fs-hadoop/
+    cp $FLINK_HOME/opt/flink-gs-fs-hadoop-1.20.5.jar $FLINK_HOME/plugins/gs-fs-hadoop/
 USER flink
 
 # ── AWS ────────────────────────────────────────────────────────────────────
 FROM base AS aws
 ENV cloud_storage_type=aws
 RUN mkdir -p $FLINK_HOME/plugins/s3-fs-presto && \
-    cp $FLINK_HOME/opt/flink-s3-fs-presto-1.18.1.jar $FLINK_HOME/plugins/s3-fs-presto/
+    cp $FLINK_HOME/opt/flink-s3-fs-presto-1.20.5.jar $FLINK_HOME/plugins/s3-fs-presto/
 USER flink

--- a/jobs-distribution/Dockerfile
+++ b/jobs-distribution/Dockerfile
@@ -6,10 +6,10 @@ RUN apt-get update && apt-get dist-upgrade -y && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
 RUN rm -f /opt/flink/lib/log4j-*.jar && \
-    curl -fsSL https://repo1.maven.org/maven2/org/apache/logging/log4j/log4j-core/2.17.1/log4j-core-2.17.1.jar -o /opt/flink/lib/log4j-core-2.17.1.jar && \
-    curl -fsSL https://repo1.maven.org/maven2/org/apache/logging/log4j/log4j-api/2.17.1/log4j-api-2.17.1.jar -o /opt/flink/lib/log4j-api-2.17.1.jar && \
-    curl -fsSL https://repo1.maven.org/maven2/org/apache/logging/log4j/log4j-slf4j-impl/2.17.1/log4j-slf4j-impl-2.17.1.jar -o /opt/flink/lib/log4j-slf4j-impl-2.17.1.jar && \
-    curl -fsSL https://repo1.maven.org/maven2/org/apache/logging/log4j/log4j-1.2-api/2.17.1/log4j-1.2-api-2.17.1.jar -o /opt/flink/lib/log4j-1.2-api-2.17.1.jar
+    curl -fsSL https://repo1.maven.org/maven2/org/apache/logging/log4j/log4j-core/2.24.3/log4j-core-2.24.3.jar -o /opt/flink/lib/log4j-core-2.24.3.jar && \
+    curl -fsSL https://repo1.maven.org/maven2/org/apache/logging/log4j/log4j-api/2.24.3/log4j-api-2.24.3.jar -o /opt/flink/lib/log4j-api-2.24.3.jar && \
+    curl -fsSL https://repo1.maven.org/maven2/org/apache/logging/log4j/log4j-slf4j-impl/2.24.3/log4j-slf4j-impl-2.24.3.jar -o /opt/flink/lib/log4j-slf4j-impl-2.24.3.jar && \
+    curl -fsSL https://repo1.maven.org/maven2/org/apache/logging/log4j/log4j-1.2-api/2.24.3/log4j-1.2-api-2.24.3.jar -o /opt/flink/lib/log4j-1.2-api-2.24.3.jar
 
 COPY target/jobs-distribution-1.0.tar.gz /tmp
 USER flink

--- a/jobs-distribution/pom.xml
+++ b/jobs-distribution/pom.xml
@@ -15,12 +15,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.apache.flink</groupId>
-            <artifactId>flink-streaming-scala_${scala.version}</artifactId>
-            <version>${flink.version}</version>
-            <type>jar</type>
-        </dependency>
-        <dependency>
             <groupId>org.sunbird</groupId>
             <artifactId>collection-cert-pre-processor</artifactId>
             <version>1.0.0</version>

--- a/lms-jobs/credential-generator/collection-cert-pre-processor/pom.xml
+++ b/lms-jobs/credential-generator/collection-cert-pre-processor/pom.xml
@@ -22,7 +22,7 @@
   <dependencies>
     <dependency>
       <groupId>org.apache.flink</groupId>
-      <artifactId>flink-streaming-scala_${scala.version}</artifactId>
+      <artifactId>flink-streaming-java</artifactId>
       <version>${flink.version}</version>
       <scope>provided</scope>
     </dependency>
@@ -113,6 +113,7 @@
               <goal>shade</goal>
             </goals>
             <configuration>
+              <createDependencyReducedPom>false</createDependencyReducedPom>
               <artifactSet>
                 <excludes>
                   <exclude>com.google.code.findbugs:jsr305</exclude>

--- a/lms-jobs/credential-generator/collection-cert-pre-processor/src/main/scala/org/sunbird/job/collectioncert/task/CollectionCertPreProcessorConfig.scala
+++ b/lms-jobs/credential-generator/collection-cert-pre-processor/src/main/scala/org/sunbird/job/collectioncert/task/CollectionCertPreProcessorConfig.scala
@@ -3,7 +3,7 @@ package org.sunbird.job.collectioncert.task
 import com.typesafe.config.Config
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.java.typeutils.TypeExtractor
-import org.apache.flink.streaming.api.scala.OutputTag
+import org.apache.flink.util.OutputTag
 import org.sunbird.job.BaseJobConfig
 
 import java.util
@@ -29,9 +29,9 @@ class CollectionCertPreProcessorConfig(override val config: Config) extends Base
     
     //Tags
     val generateCertificateOutputTagName = "generate-certificate-request"
-    val generateCertificateOutputTag: OutputTag[String] = OutputTag[String](generateCertificateOutputTagName)
+    val generateCertificateOutputTag: OutputTag[String] = new OutputTag[String](generateCertificateOutputTagName, stringTypeInfo)
     val failedEventOutputTagName = "failed-events"
-    val failedEventOutputTag: OutputTag[String] = OutputTag[String](failedEventOutputTagName)
+    val failedEventOutputTag: OutputTag[String] = new OutputTag[String](failedEventOutputTagName, stringTypeInfo)
     val kafkaFailedTopic: String = config.getString("kafka.output.failed.topic")
 
     //Cassandra configfailedEventOutputTag

--- a/lms-jobs/credential-generator/collection-certificate-generator/pom.xml
+++ b/lms-jobs/credential-generator/collection-certificate-generator/pom.xml
@@ -21,7 +21,7 @@
 	<dependencies>
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-streaming-scala_${scala.version}</artifactId>
+			<artifactId>flink-streaming-java</artifactId>
 			<version>${flink.version}</version>
 			<scope>provided</scope>
 		</dependency>
@@ -117,6 +117,7 @@
 							<goal>shade</goal>
 						</goals>
 						<configuration>
+							<createDependencyReducedPom>false</createDependencyReducedPom>
 							<artifactSet>
 								<excludes>
 									<exclude>com.google.code.findbugs:jsr305</exclude>

--- a/lms-jobs/credential-generator/collection-certificate-generator/src/main/scala/org/sunbird/job/certgen/task/CertificateGeneratorConfig.scala
+++ b/lms-jobs/credential-generator/collection-certificate-generator/src/main/scala/org/sunbird/job/certgen/task/CertificateGeneratorConfig.scala
@@ -5,7 +5,7 @@ import java.util
 import com.typesafe.config.Config
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.java.typeutils.TypeExtractor
-import org.apache.flink.streaming.api.scala.OutputTag
+import org.apache.flink.util.OutputTag
 import org.sunbird.job.BaseJobConfig
 import org.sunbird.job.certgen.functions.{NotificationMetaData, UserFeedMetaData}
 
@@ -140,9 +140,9 @@ class CertificateGeneratorConfig(override val config: Config) extends BaseJobCon
 
   // Tags
   val auditEventOutputTagName = "audit-events"
-  val auditEventOutputTag: OutputTag[String] = OutputTag[String](auditEventOutputTagName)
-  val notifierOutputTag: OutputTag[NotificationMetaData] = OutputTag[NotificationMetaData]("notifier")
-  val userFeedOutputTag: OutputTag[UserFeedMetaData] = OutputTag[UserFeedMetaData]("user-feed")
+  val auditEventOutputTag: OutputTag[String] = new OutputTag[String](auditEventOutputTagName, stringTypeInfo)
+  val notifierOutputTag: OutputTag[NotificationMetaData] = new OutputTag[NotificationMetaData]("notifier", notificationMetaTypeInfo)
+  val userFeedOutputTag: OutputTag[UserFeedMetaData] = new OutputTag[UserFeedMetaData]("user-feed", userFeeMetaTypeInfo)
   
   //UserFeed constants
   val priority: String = "priority"
@@ -163,7 +163,7 @@ class CertificateGeneratorConfig(override val config: Config) extends BaseJobCon
   val generateCertificateProducer = "generate-certificate-sink"
   val generateCertificateParallelism:Int = config.getInt("task.generate_certificate.parallelism")
   val generateCertificateOutputTagName = "generate-certificate-request"
-  val generateCertificateOutputTag: OutputTag[String] = OutputTag[String](generateCertificateOutputTagName)
+  val generateCertificateOutputTag: OutputTag[String] = new OutputTag[String](generateCertificateOutputTagName, stringTypeInfo)
   val courseTable: String = config.getString("lms-cassandra.course_batch.table")
   val assessmentTable: String = config.getString("lms-cassandra.assessment_aggregator.table")
   val userActivityAggTable: String = config.getString("lms-cassandra.user_activity_agg.table")

--- a/lms-jobs/credential-generator/collection-certificate-generator/src/main/scala/org/sunbird/job/certgen/task/CertificateGeneratorStreamTask.scala
+++ b/lms-jobs/credential-generator/collection-certificate-generator/src/main/scala/org/sunbird/job/certgen/task/CertificateGeneratorStreamTask.scala
@@ -8,7 +8,8 @@ import org.apache.flink.api.java.functions.KeySelector
 import org.apache.flink.api.java.typeutils.TypeExtractor
 import org.apache.flink.api.java.utils.ParameterTool
 import org.apache.flink.api.common.eventtime.WatermarkStrategy
-import org.apache.flink.streaming.api.scala.{DataStream, StreamExecutionEnvironment}
+import org.apache.flink.streaming.api.datastream.DataStream
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment
 import org.sunbird.job.certgen.domain.Event
 import org.sunbird.job.certgen.functions.{CertificateGeneratorFunction, CreateUserFeedFunction, NotificationMetaData, NotifierFunction, UserFeedMetaData}
 import org.sunbird.job.collectioncert.functions.CollectionCertPreProcessorFn

--- a/lms-jobs/credential-generator/collection-certificate-generator/src/test/scala/org/sunbird/job/certgen/spec/CertificateGeneratorFunctionTaskTestSpec.scala
+++ b/lms-jobs/credential-generator/collection-certificate-generator/src/test/scala/org/sunbird/job/certgen/spec/CertificateGeneratorFunctionTaskTestSpec.scala
@@ -11,7 +11,7 @@ import org.apache.flink.runtime.client.JobExecutionException
 import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration
 import org.apache.flink.streaming.api.functions.source.SourceFunction
 import org.apache.flink.streaming.api.functions.source.SourceFunction.SourceContext
-import org.apache.flink.streaming.api.scala.StreamExecutionEnvironment
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment
 import org.apache.flink.test.util.MiniClusterWithClientResource
 import org.cassandraunit.CQLDataLoader
 import org.cassandraunit.dataset.cql.FileCQLDataSet

--- a/lms-jobs/credential-generator/legacy-certificate-migrator/pom.xml
+++ b/lms-jobs/credential-generator/legacy-certificate-migrator/pom.xml
@@ -21,7 +21,7 @@
 	<dependencies>
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-streaming-scala_${scala.version}</artifactId>
+			<artifactId>flink-streaming-java</artifactId>
 			<version>${flink.version}</version>
 			<scope>provided</scope>
 		</dependency>
@@ -112,6 +112,7 @@
 							<goal>shade</goal>
 						</goals>
 						<configuration>
+							<createDependencyReducedPom>false</createDependencyReducedPom>
 							<artifactSet>
 								<excludes>
 									<exclude>com.google.code.findbugs:jsr305</exclude>

--- a/lms-jobs/credential-generator/legacy-certificate-migrator/src/main/scala/org/sunbird/job/certmigrator/task/CertificateGeneratorConfig.scala
+++ b/lms-jobs/credential-generator/legacy-certificate-migrator/src/main/scala/org/sunbird/job/certmigrator/task/CertificateGeneratorConfig.scala
@@ -3,7 +3,7 @@ package org.sunbird.job.certmigrator.task
 import com.typesafe.config.Config
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.java.typeutils.TypeExtractor
-import org.apache.flink.streaming.api.scala.OutputTag
+import org.apache.flink.util.OutputTag
 import org.sunbird.job.BaseJobConfig
 
 import java.util
@@ -103,7 +103,7 @@ class CertificateGeneratorConfig(override val config: Config) extends BaseJobCon
 
   // Tags
   val auditEventOutputTagName = "audit-events"
-  val auditEventOutputTag: OutputTag[String] = OutputTag[String](auditEventOutputTagName)
+  val auditEventOutputTag: OutputTag[String] = new OutputTag[String](auditEventOutputTagName, stringTypeInfo)
 
   //UserFeed constants
   val cloudStoreBasePath = config.getString("cloud_storage_base_url")

--- a/lms-jobs/credential-generator/legacy-certificate-migrator/src/main/scala/org/sunbird/job/certmigrator/task/CertificateGeneratorStreamTask.scala
+++ b/lms-jobs/credential-generator/legacy-certificate-migrator/src/main/scala/org/sunbird/job/certmigrator/task/CertificateGeneratorStreamTask.scala
@@ -8,7 +8,8 @@ import org.apache.flink.api.java.functions.KeySelector
 import org.apache.flink.api.java.typeutils.TypeExtractor
 import org.apache.flink.api.java.utils.ParameterTool
 import org.apache.flink.api.common.eventtime.WatermarkStrategy
-import org.apache.flink.streaming.api.scala.{DataStream, StreamExecutionEnvironment}
+import org.apache.flink.streaming.api.datastream.DataStream
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment
 import org.sunbird.job.certmigrator.domain.Event
 import org.sunbird.job.certmigrator.functions.CertificateGeneratorFunction
 import org.sunbird.job.connector.FlinkKafkaConnector

--- a/ml-jobs/ml-transfer-ownership/pom.xml
+++ b/ml-jobs/ml-transfer-ownership/pom.xml
@@ -28,7 +28,7 @@
     <dependencies>
         <dependency>
             <groupId>org.apache.flink</groupId>
-            <artifactId>flink-streaming-scala_${scala.version}</artifactId>
+            <artifactId>flink-streaming-java</artifactId>
             <version>${flink.version}</version>
             <scope>provided</scope>
         </dependency>

--- a/ml-jobs/ml-transfer-ownership/src/main/scala/org/sunbird/job/transferownership/task/TransferOwnershipStreamTask.scala
+++ b/ml-jobs/ml-transfer-ownership/src/main/scala/org/sunbird/job/transferownership/task/TransferOwnershipStreamTask.scala
@@ -6,7 +6,8 @@ import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.java.typeutils.TypeExtractor
 import org.apache.flink.api.java.utils.ParameterTool
 import org.apache.flink.api.common.eventtime.WatermarkStrategy
-import org.apache.flink.streaming.api.scala.{DataStream, StreamExecutionEnvironment}
+import org.apache.flink.streaming.api.datastream.DataStream
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment
 import org.sunbird.job.connector.FlinkKafkaConnector
 import org.sunbird.job.transferownership.domain.Event
 import org.sunbird.job.transferownership.functions.TransferOwnershipFunction

--- a/ml-jobs/ml-transfer-ownership/src/test/scala/org/sunbird/transferownership/spec/TransferOwnershipFunctionTestSpec.scala
+++ b/ml-jobs/ml-transfer-ownership/src/test/scala/org/sunbird/transferownership/spec/TransferOwnershipFunctionTestSpec.scala
@@ -7,7 +7,8 @@ import de.flapdoodle.embed.mongo.{MongodExecutable, MongodProcess, MongodStarter
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.java.typeutils.TypeExtractor
 import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration
-import org.apache.flink.streaming.api.scala.StreamExecutionEnvironment
+import org.apache.flink.streaming.api.datastream.DataStream
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment
 import org.apache.flink.test.util.MiniClusterWithClientResource
 import org.mockito.Mockito
 import org.mockito.Mockito.when
@@ -58,7 +59,7 @@ class TransferOwnershipFunctionTestSpec extends BaseTestSpec {
     flinkCluster.after()
   }
 
-  def createTestStream(env: StreamExecutionEnvironment): org.apache.flink.streaming.api.scala.DataStream[Event] = {
+  def createTestStream(env: StreamExecutionEnvironment): DataStream[Event] = {
     implicit val eventTypeInfo: TypeInformation[Event] = TypeExtractor.getForClass(classOf[Event])
     env.addSource(new TransferOwnershipEventSource).name(jobConfig.mlTransferOwnershipConsumer)
       .uid(jobConfig.mlTransferOwnershipConsumer).setParallelism(jobConfig.mlTransferOwnershipParallelism).rebalance

--- a/ml-jobs/ml-user-delete/pom.xml
+++ b/ml-jobs/ml-user-delete/pom.xml
@@ -28,7 +28,7 @@
     <dependencies>
         <dependency>
             <groupId>org.apache.flink</groupId>
-            <artifactId>flink-streaming-scala_${scala.version}</artifactId>
+            <artifactId>flink-streaming-java</artifactId>
             <version>${flink.version}</version>
             <scope>provided</scope>
         </dependency>

--- a/ml-jobs/ml-user-delete/src/main/scala/org/sunbird/job/userdelete/task/UserDeleteStreamTask.scala
+++ b/ml-jobs/ml-user-delete/src/main/scala/org/sunbird/job/userdelete/task/UserDeleteStreamTask.scala
@@ -6,7 +6,8 @@ import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.java.typeutils.TypeExtractor
 import org.apache.flink.api.java.utils.ParameterTool
 import org.apache.flink.api.common.eventtime.WatermarkStrategy
-import org.apache.flink.streaming.api.scala.{DataStream, StreamExecutionEnvironment}
+import org.apache.flink.streaming.api.datastream.DataStream
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment
 import org.sunbird.job.connector.FlinkKafkaConnector
 import org.sunbird.job.userdelete.domain.Event
 import org.sunbird.job.userdelete.functions.UserDeleteFunction

--- a/ml-jobs/ml-user-delete/src/test/scala/org/sunbird/userdelete/spec/UserDeleteFunctionTestSpec.scala
+++ b/ml-jobs/ml-user-delete/src/test/scala/org/sunbird/userdelete/spec/UserDeleteFunctionTestSpec.scala
@@ -7,7 +7,8 @@ import de.flapdoodle.embed.mongo.{MongodExecutable, MongodProcess, MongodStarter
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.java.typeutils.TypeExtractor
 import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration
-import org.apache.flink.streaming.api.scala.StreamExecutionEnvironment
+import org.apache.flink.streaming.api.datastream.DataStream
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment
 import org.apache.flink.test.util.MiniClusterWithClientResource
 import org.mockito.Mockito
 import org.mockito.Mockito.when
@@ -59,7 +60,7 @@ class UserDeleteFunctionTestSpec extends BaseTestSpec {
     flinkCluster.after()
   }
 
-  def createTestStream(env: StreamExecutionEnvironment): org.apache.flink.streaming.api.scala.DataStream[Event] = {
+  def createTestStream(env: StreamExecutionEnvironment): DataStream[Event] = {
     implicit val eventTypeInfo: TypeInformation[Event] = TypeExtractor.getForClass(classOf[Event])
     env.addSource(new UserDeleteEventSource).name(jobConfig.mlUserDeleteConsumer)
       .uid(jobConfig.mlUserDeleteConsumer).setParallelism(jobConfig.mlUserDeleteParallelism).rebalance

--- a/ml-jobs/program-user-info/pom.xml
+++ b/ml-jobs/program-user-info/pom.xml
@@ -31,7 +31,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.flink</groupId>
-            <artifactId>flink-streaming-scala_${scala.version}</artifactId>
+            <artifactId>flink-streaming-java</artifactId>
             <version>${flink.version}</version>
             <scope>provided</scope>
         </dependency>
@@ -110,6 +110,7 @@
                             <goal>shade</goal>
                         </goals>
                         <configuration>
+                            <createDependencyReducedPom>false</createDependencyReducedPom>
                             <artifactSet>
                                 <excludes>
                                     <exclude>com.google.code.findbugs:jsr305</exclude>

--- a/ml-jobs/program-user-info/src/main/scala/org/sunbird/job/userinfo/task/ProgramUserInfoStreamTask.scala
+++ b/ml-jobs/program-user-info/src/main/scala/org/sunbird/job/userinfo/task/ProgramUserInfoStreamTask.scala
@@ -5,7 +5,8 @@ import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.java.typeutils.TypeExtractor
 import org.apache.flink.api.java.utils.ParameterTool
 import org.apache.flink.api.common.eventtime.WatermarkStrategy
-import org.apache.flink.streaming.api.scala.{DataStream, StreamExecutionEnvironment}
+import org.apache.flink.streaming.api.datastream.DataStream
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment
 import org.sunbird.job.connector.FlinkKafkaConnector
 import org.sunbird.job.userinfo.domain.Event
 import org.sunbird.job.userinfo.functions.ProgramUserInfoFunction

--- a/ml-jobs/program-user-info/src/test/scala/org/sunbird/job/spec/ProgramUserInfoTaskTestSpec.scala
+++ b/ml-jobs/program-user-info/src/test/scala/org/sunbird/job/spec/ProgramUserInfoTaskTestSpec.scala
@@ -7,7 +7,7 @@ import org.apache.flink.api.java.typeutils.TypeExtractor
 import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration
 import org.apache.flink.streaming.api.functions.source.SourceFunction
 import org.apache.flink.streaming.api.functions.source.SourceFunction.SourceContext
-import org.apache.flink.streaming.api.scala.StreamExecutionEnvironment
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment
 import org.apache.flink.test.util.MiniClusterWithClientResource
 import org.cassandraunit.CQLDataLoader
 import org.cassandraunit.dataset.cql.FileCQLDataSet

--- a/notification/notification-job/pom.xml
+++ b/notification/notification-job/pom.xml
@@ -23,7 +23,7 @@
     <dependencies>
         <dependency>
             <groupId>org.apache.flink</groupId>
-            <artifactId>flink-streaming-scala_${scala.version}</artifactId>
+            <artifactId>flink-streaming-java</artifactId>
             <version>${flink.version}</version>
         </dependency>
         <dependency>
@@ -137,6 +137,7 @@
                             <goal>shade</goal>
                         </goals>
                         <configuration>
+                            <createDependencyReducedPom>false</createDependencyReducedPom>
                             <artifactSet>
                                 <excludes>
                                     <exclude>com.google.code.findbugs:jsr305</exclude>

--- a/notification/notification-job/src/main/scala/org/sunbird/job/notification/task/NotificationConfig.scala
+++ b/notification/notification-job/src/main/scala/org/sunbird/job/notification/task/NotificationConfig.scala
@@ -4,7 +4,7 @@ import org.sunbird.job.BaseJobConfig
 import com.typesafe.config.Config
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.java.typeutils.TypeExtractor
-import org.apache.flink.streaming.api.scala.OutputTag
+import org.apache.flink.util.OutputTag
 import org.sunbird.job.notification.domain.NotificationMessage
 
 class NotificationConfig(override val config: Config) extends BaseJobConfig(config, "notification-trigger") {
@@ -38,6 +38,6 @@ class NotificationConfig(override val config: Config) extends BaseJobConfig(conf
     
     //val notificationFailedOutputTag: OutputTag[NotificationMessage] = OutputTag[NotificationMessage]("notification-failed")
     val notificationFailedOutputTagName = "notification-failed-events"
-    val notificationFailedOutputTag: OutputTag[String] = OutputTag[String](notificationFailedOutputTagName)
+    val notificationFailedOutputTag: OutputTag[String] = new OutputTag[String](notificationFailedOutputTagName, stringTypeInfo)
     
 }

--- a/notification/notification-job/src/main/scala/org/sunbird/job/notification/task/NotificationStreamTask.scala
+++ b/notification/notification-job/src/main/scala/org/sunbird/job/notification/task/NotificationStreamTask.scala
@@ -8,7 +8,8 @@ import org.apache.flink.api.java.functions.KeySelector
 import org.apache.flink.api.java.typeutils.TypeExtractor
 import org.apache.flink.api.java.utils.ParameterTool
 import org.apache.flink.api.common.eventtime.WatermarkStrategy
-import org.apache.flink.streaming.api.scala.{DataStream, StreamExecutionEnvironment}
+import org.apache.flink.streaming.api.datastream.DataStream
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment
 import org.slf4j.LoggerFactory
 import org.sunbird.job.connector.FlinkKafkaConnector
 import org.sunbird.job.util.FlinkUtil

--- a/notification/notification-job/src/test/scala/org/sunbird/job/notification/spec/NotificationFunctionTaskTestSpec.scala
+++ b/notification/notification-job/src/test/scala/org/sunbird/job/notification/spec/NotificationFunctionTaskTestSpec.scala
@@ -12,7 +12,7 @@ import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration
 import org.apache.flink.streaming.api.functions.sink.SinkFunction
 import org.apache.flink.streaming.api.functions.source.SourceFunction
 import org.apache.flink.streaming.api.functions.source.SourceFunction.SourceContext
-import org.apache.flink.streaming.api.scala.StreamExecutionEnvironment
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment
 import org.apache.flink.test.util.MiniClusterWithClientResource
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when

--- a/notification/notification-sdk/pom.xml
+++ b/notification/notification-sdk/pom.xml
@@ -137,6 +137,7 @@
 							<goal>shade</goal>
 						</goals>
 						<configuration>
+							<createDependencyReducedPom>false</createDependencyReducedPom>
 							<artifactSet>
 								<excludes>
 									<exclude>classworlds:classworlds</exclude>

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<scala.version>2.12</scala.version>
 		<scala.maj.version>2.12.19</scala.maj.version>
-		<flink.version>1.18.1</flink.version>
+		<flink.version>1.20.5</flink.version>
 		<kafka.version>3.7.1</kafka.version>
 		<jackson-jaxrs.version>1.9.13</jackson-jaxrs.version>
 		<com.fasterxml.jackson.version>2.18.6</com.fasterxml.jackson.version>
@@ -352,17 +352,6 @@
 			</dependency>
 			<dependency>
 				<groupId>org.apache.flink</groupId>
-				<artifactId>flink-streaming-scala_${scala.version}</artifactId>
-				<version>${flink.version}</version>
-				<exclusions>
-					<exclusion>
-						<groupId>org.lz4</groupId>
-						<artifactId>lz4-java</artifactId>
-					</exclusion>
-				</exclusions>
-			</dependency>
-			<dependency>
-				<groupId>org.apache.flink</groupId>
 				<artifactId>flink-test-utils</artifactId>
 				<version>${flink.version}</version>
 				<exclusions>
@@ -375,7 +364,7 @@
 			<dependency>
 				<groupId>org.apache.flink</groupId>
 				<artifactId>flink-connector-kafka</artifactId>
-				<version>3.2.0-1.18</version>
+				<version>3.4.0-1.20</version>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.flink</groupId>

--- a/user-org-jobs/user-deletion-cleanup/pom.xml
+++ b/user-org-jobs/user-deletion-cleanup/pom.xml
@@ -31,7 +31,7 @@
     <dependencies>
         <dependency>
             <groupId>org.apache.flink</groupId>
-            <artifactId>flink-streaming-scala_${scala.version}</artifactId>
+            <artifactId>flink-streaming-java</artifactId>
             <version>${flink.version}</version>
             <scope>provided</scope>
         </dependency>
@@ -197,6 +197,7 @@
                             <goal>shade</goal>
                         </goals>
                         <configuration>
+                            <createDependencyReducedPom>false</createDependencyReducedPom>
                             <artifactSet>
                                 <excludes>
                                     <exclude>com.google.code.findbugs:jsr305</exclude>

--- a/user-org-jobs/user-deletion-cleanup/src/main/scala/org/sunbird/job/deletioncleanup/task/UserDeletionCleanupConfig.scala
+++ b/user-org-jobs/user-deletion-cleanup/src/main/scala/org/sunbird/job/deletioncleanup/task/UserDeletionCleanupConfig.scala
@@ -3,13 +3,14 @@ package org.sunbird.job.deletioncleanup.task
 import com.typesafe.config.Config
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.java.typeutils.TypeExtractor
-import org.apache.flink.streaming.api.scala.OutputTag
+import org.apache.flink.util.OutputTag
 import org.sunbird.job.BaseJobConfig
 import org.sunbird.job.deletioncleanup.domain.Event
 
 class UserDeletionCleanupConfig(override val config: Config) extends BaseJobConfig(config, "UserDeletionCleanupConfig") {
 
   implicit val mapTypeInfo: TypeInformation[Event] = TypeExtractor.getForClass(classOf[Event])
+  implicit val stringTypeInfo: TypeInformation[String] = TypeExtractor.getForClass(classOf[String])
 
   // Kafka Topics Configuration
   val inputTopic: String = config.getString("kafka.input.topic")
@@ -23,7 +24,7 @@ class UserDeletionCleanupConfig(override val config: Config) extends BaseJobConf
   val totalEventsCount ="total-delete-events-count"
 
   val auditEventOutputTagName = "audit-events"
-  val auditEventOutputTag: OutputTag[String] = OutputTag[String](auditEventOutputTagName)
+  val auditEventOutputTag: OutputTag[String] = new OutputTag[String](auditEventOutputTagName, stringTypeInfo)
 
   val dbHost: String = config.getString("lms-cassandra.host")
   val dbPort: Int = config.getInt("lms-cassandra.port")

--- a/user-org-jobs/user-deletion-cleanup/src/main/scala/org/sunbird/job/deletioncleanup/task/UserDeletionCleanupStreamTask.scala
+++ b/user-org-jobs/user-deletion-cleanup/src/main/scala/org/sunbird/job/deletioncleanup/task/UserDeletionCleanupStreamTask.scala
@@ -6,7 +6,8 @@ import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.java.typeutils.TypeExtractor
 import org.apache.flink.api.java.utils.ParameterTool
 import org.apache.flink.api.common.eventtime.WatermarkStrategy
-import org.apache.flink.streaming.api.scala.{DataStream, StreamExecutionEnvironment}
+import org.apache.flink.streaming.api.datastream.DataStream
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment
 import org.sunbird.job.connector.FlinkKafkaConnector
 import org.sunbird.job.deletioncleanup.domain.Event
 import org.sunbird.job.deletioncleanup.functions.UserDeletionCleanupFunction

--- a/user-org-jobs/user-deletion-cleanup/src/test/scala/org/sunbird/deletioncleanup/spec/UserDeletionCleanupFunctionTestSpec.scala
+++ b/user-org-jobs/user-deletion-cleanup/src/test/scala/org/sunbird/deletioncleanup/spec/UserDeletionCleanupFunctionTestSpec.scala
@@ -10,7 +10,7 @@ import org.cassandraunit.dataset.cql.FileCQLDataSet
 import org.cassandraunit.utils.EmbeddedCassandraServerHelper
 import org.mockito.Mockito
 import org.mockito.Mockito.when
-import org.apache.flink.streaming.api.scala.StreamExecutionEnvironment
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment
 import org.sunbird.job.connector.FlinkKafkaConnector
 import org.sunbird.job.util.{CassandraUtil, FlinkUtil, HTTPResponse, HttpUtil}
 import org.sunbird.job.deletioncleanup.domain.Event

--- a/user-org-jobs/user-ownership-transfer/pom.xml
+++ b/user-org-jobs/user-ownership-transfer/pom.xml
@@ -30,7 +30,7 @@
     <dependencies>
         <dependency>
             <groupId>org.apache.flink</groupId>
-            <artifactId>flink-streaming-scala_${scala.version}</artifactId>
+            <artifactId>flink-streaming-java</artifactId>
             <version>${flink.version}</version>
             <scope>provided</scope>
         </dependency>

--- a/user-org-jobs/user-ownership-transfer/src/main/scala/org/sunbird/job/ownershiptransfer/task/UserOwnershipTransferStreamTask.scala
+++ b/user-org-jobs/user-ownership-transfer/src/main/scala/org/sunbird/job/ownershiptransfer/task/UserOwnershipTransferStreamTask.scala
@@ -6,7 +6,8 @@ import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.java.typeutils.TypeExtractor
 import org.apache.flink.api.java.utils.ParameterTool
 import org.apache.flink.api.common.eventtime.WatermarkStrategy
-import org.apache.flink.streaming.api.scala.{DataStream, StreamExecutionEnvironment}
+import org.apache.flink.streaming.api.datastream.DataStream
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment
 import org.sunbird.job.connector.FlinkKafkaConnector
 import org.sunbird.job.ownershiptransfer.domain.Event
 import org.sunbird.job.ownershiptransfer.functions.UserOwnershipTransferFunction

--- a/user-org-jobs/user-ownership-transfer/src/test/scala/org/sunbird/ownershiptransfer/spec/UserOwnershipTransferFunctionTestSpec.scala
+++ b/user-org-jobs/user-ownership-transfer/src/test/scala/org/sunbird/ownershiptransfer/spec/UserOwnershipTransferFunctionTestSpec.scala
@@ -4,7 +4,8 @@ import com.typesafe.config.{Config, ConfigFactory}
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.java.typeutils.TypeExtractor
 import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration
-import org.apache.flink.streaming.api.scala.StreamExecutionEnvironment
+import org.apache.flink.streaming.api.datastream.DataStream
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment
 import org.apache.flink.test.util.MiniClusterWithClientResource
 import org.cassandraunit.CQLDataLoader
 import org.cassandraunit.dataset.cql.FileCQLDataSet
@@ -162,7 +163,7 @@ class UserOwnershipTransferFunctionTestSpec extends BaseTestSpec {
   def testCassandraUtil(cassandraUtil: CassandraUtil): Unit = {
     cassandraUtil.reconnect()
   }
-  def createTestStream(env: StreamExecutionEnvironment): org.apache.flink.streaming.api.scala.DataStream[Event] = {
+  def createTestStream(env: StreamExecutionEnvironment): DataStream[Event] = {
     implicit val eventTypeInfo: TypeInformation[Event] = TypeExtractor.getForClass(classOf[Event])
     env.addSource(new UserOwnershipTransferEventSource).name(jobConfig.userOwnershipTransferConsumer)
       .uid(jobConfig.userOwnershipTransferConsumer).setParallelism(jobConfig.userOwnershipTransferParallelism).rebalance


### PR DESCRIPTION
Upgrades Apache Flink from 1.18.1 to 1.20.5 across all job modules. Migrates off the deprecated `flink-streaming-scala` API (removed in Flink 2.0) to `flink-streaming-java`/Java DataStream types, bumps `flink-connector-kafka` to `3.4.0-1.20`, and fixes a stale log4j pin in the Docker image that crashed the TaskManager on startup against the new base image.

Dependencies required: `org.apache.flink:flink-connector-kafka:3.4.0-1.20`, `org.apache.flink:flink-streaming-java:1.20.5` (replacing `flink-streaming-scala_2.12`), log4j2 `2.24.3` (matches what Flink 1.20.5 already bundles).

### Type of change

Please choose appropriate options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
